### PR TITLE
Fix broken `project-urls.Issues` link in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ dependencies = [
 
 [project.urls]
 Repository = "https://github.com/kfithen/RomanEmpireReminder"
-Issues = "https://github.com/me/kfithen/RomanEmpireReminder/issues"
+Issues = "https://github.com/kfithen/RomanEmpireReminder/issues"


### PR DESCRIPTION
I've just found I messed up `project-urls.Issues` in my initial `pyproject.toml` commit, it should be set to "https://github.com/kfithen/RomanEmpireReminder/issues", but is currently set to "https://github.com/me/kfithen/RomanEmpireReminder/issues"; this commit remedies that. Oops, that one's my fault, lol!